### PR TITLE
Add introduction and contents list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,7 @@
 
 If you're reading this and thinking about contributing, then welcome aboard! :wave:  
 
-This project is intended to encourage _participation_ and _collaboration_ across the BBC News team and the wider community in shaping how we write software and create brilliant products together.  
-
 Below are a few pointers on ways you can help us out...
-
 
 
 ### Open a pull request

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# News and Weather Apps Team Developer Docs
-[Clean Code Guide](https://github.com/bbc/news-apps-developer-docs/blob/master/clean-code-guide.md)
+## Playbook
 
-[News Apps Public](https://github.com/BBC-News/news-app-public)
+Welcome to the BBC News Apps playbook! :closed_book::sparkles:
+
+The playbook is a living document for us to detail our team practices. The project is intended to encourage _participation_ and _collaboration_ across the News Apps team and the wider community in shaping how we write software and create brilliant products together.
+
+### Contents
+- [Git](https://github.com/bbc/news-apps-playbook/blob/master/git/README.md)
+  - [Commit messages](https://github.com/bbc/news-apps-playbook/blob/master/git/commit-messages.md)
+  - [Pull requests](https://github.com/bbc/news-apps-playbook/blob/master/git/pull-requests.md)
+- [Android](https://github.com/bbc/news-apps-playbook/blob/master/android/README.md)
+  - [Kotlin style guide](https://github.com/bbc/news-apps-playbook/blob/master/android/kotlin.md)
+- [iOS](https://github.com/bbc/news-apps-playbook/blob/master/ios/README.md)
+  - [Swift style guide](https://docs.google.com/document/d/1jXrss9JX3Cih42upizLPGDcPbjvoCObRhL8-oBhzZXU/edit)
+
+### Contributing
+To contribute to the playbook, you can [create a pull request](https://github.com/bbc/news-apps-playbook/pull/new/master) or [open an issue](https://github.com/bbc/news-apps-playbook/issues).
+
+Read the full guidelines for contributing [here](https://github.com/bbc/news-apps-playbook/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
A simple introduction to the playbook with a list of contents.

I've moved the paragraph from the contributing guidelines that explains the motivation behind the playbook into the introduction.